### PR TITLE
Specify OpenSSL specific versions supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ load_module modules/ngx_http_jwt_cf_module.so;
 This module depends on the [JWT C Library](https://github.com/benmcollins/libjwt)
 
 Transitively, that library depends on a JSON Parser called
-[Jansson](https://github.com/akheron/jansson) as well as the OpenSSL library.
+[Jansson](https://github.com/akheron/jansson) as well as the OpenSSL library (versions >= 1.1.0).
 
 Also required is [libcurl](https://curl.haxx.se/libcurl/).
 


### PR DESCRIPTION
Because it fails to compile with OpenSSL 1.0:

> nginx-cloudflare-jwt-checker-0/src/ngx_http_jwt_cf_jwk_decode.c:85:5: error: implicit declaration of function 'RSA_set0_key'; did you mean 'RSA_check_key'